### PR TITLE
Corrected SoC key definition

### DIFF
--- a/custom_components/openwbmqtt/const.py
+++ b/custom_components/openwbmqtt/const.py
@@ -130,7 +130,7 @@ SENSORS_PER_LP = [
         valueMap={1: True, 0: False},
     ),
     openwbSensorEntityDescription(
-        key="%SoC",
+        key="%Soc",
         name="% SoC",
         device_class=DEVICE_CLASS_BATTERY,
         native_unit_of_measurement=PERCENTAGE,


### PR DESCRIPTION
The definition of key for the SOC was wrong. It was "%SoC", but it should be "%Soc"